### PR TITLE
Add trial functionality to purchaseValidationApp

### DIFF
--- a/MacForge/purchaseValidationApp/AppDelegate.m
+++ b/MacForge/purchaseValidationApp/AppDelegate.m
@@ -60,11 +60,17 @@
 - (void)didDismissPaddleUIType:(PADUIType)uiType triggeredUIType:(PADTriggeredUIType)triggeredUIType product:(nonnull PADProduct *)product {
 //    NSLog(@"%ld : %ld : %@", (long)uiType, (long)triggeredUIType, product);
     
-    if (triggeredUIType == 6) {
-        // Quit pressed
-        exit(1337);
-    } else {
-        [self checkEm:product];
+    switch (triggeredUIType) {
+        case PADTriggeredUITypeCancel:
+            // Quit pressed
+            exit(1337);
+            break;
+        case PADTriggeredUITypeContinueTrial:
+            //Continue trial pressed
+            exit(69);
+            break;
+        default:
+            [self checkEm:product];
     }
 }
 


### PR DESCRIPTION
purchaseValidationApp would not exit if 'Continue Trial' was pressed in the paddle checkout form resulting in the callee completion handler never being called. This commit adds a check for `PADTriggeredUITypeContinueTrial` in Paddle delegate method `didDismissPaddleUIType:(PADUIType)uiType triggeredUIType:(PADTriggeredUIType)triggeredUIType product:(nonnull PADProduct *)product` and exits with the proper status.

To avoid ending up with a massive `if else` block down the line if more `triggeredUIType`s need to be handled I have converted the checks to a `switch` statement.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ NA] Does your submission pass tests?
2. [ NA] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] Have you written new tests for your core changes, as applicable?
* [NA] Have you successfully ran tests with your changes locally?
